### PR TITLE
Remove warning output from TcpClient#send

### DIFF
--- a/lib/cod/tcp_client.rb
+++ b/lib/cod/tcp_client.rb
@@ -173,7 +173,6 @@ module Cod
       @connection.write(
         @serializer.en(msg))
     rescue Exception => e
-      warn e
       raise
     end
 


### PR DESCRIPTION
I was getting "closed stream" console output while running a TCP client/server and traced it to `TcpClient#send`. Because the exception is re-raised, I don't think it's necessary to `warn` since any clients can handle any raised exceptions themselves.

In other words, it's trivial for clients to duplicate this behavior, but there's no way to suppress it.
